### PR TITLE
Propagate role/phase tags through dynamic include_tasks

### DIFF
--- a/roles/argocd/tasks/main.yml
+++ b/roles/argocd/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "argocd"
+        - "install"
   when: argocd_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "argocd"
+        - "uninstall"
   when: not argocd_enabled
   tags: ["always"]

--- a/roles/atlantis/tasks/main.yml
+++ b/roles/atlantis/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "atlantis"
+        - "install"
   when: atlantis_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "atlantis"
+        - "uninstall"
   when: not atlantis_enabled
   tags: ["always"]

--- a/roles/clamav/tasks/main.yml
+++ b/roles/clamav/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "clamav"
+        - "install"
   when: clamav_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "clamav"
+        - "uninstall"
   when: not clamav_enabled
   tags: ["always"]

--- a/roles/gatus/tasks/main.yml
+++ b/roles/gatus/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "gatus"
+        - "install"
   when: gatus_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "gatus"
+        - "uninstall"
   when: not gatus_enabled
   tags: ["always"]

--- a/roles/gitlab_runner/tasks/main.yml
+++ b/roles/gitlab_runner/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "gitlab_runner"
+        - "install"
   when: gitlab_runner_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "gitlab_runner"
+        - "uninstall"
   when: not gitlab_runner_enabled
   tags: ["always"]

--- a/roles/headlamp/tasks/main.yml
+++ b/roles/headlamp/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "headlamp"
+        - "install"
   when: headlamp_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "headlamp"
+        - "uninstall"
   when: not headlamp_enabled
   tags: ["always"]

--- a/roles/mailcrab/tasks/main.yml
+++ b/roles/mailcrab/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "mailcrab"
+        - "install"
   when: mailcrab_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "mailcrab"
+        - "uninstall"
   when: not mailcrab_enabled
   tags: ["always"]

--- a/roles/oauth2_proxy/tasks/main.yml
+++ b/roles/oauth2_proxy/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "oauth2_proxy"
+        - "install"
   when: oauth2_proxy_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "oauth2_proxy"
+        - "uninstall"
   when: not oauth2_proxy_enabled
   tags: ["always"]

--- a/roles/warpgate/tasks/main.yml
+++ b/roles/warpgate/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "warpgate"
+        - "install"
   when: warpgate_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "warpgate"
+        - "uninstall"
   when: not warpgate_enabled
   tags: ["always"]

--- a/roles/zammad/tasks/main.yml
+++ b/roles/zammad/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "zammad"
+        - "install"
   when: zammad_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "zammad"
+        - "uninstall"
   when: not zammad_enabled
   tags: ["always"]


### PR DESCRIPTION
## Proposed changes

Dynamic `include_tasks` do not propagate their tags to the included tasks, so
running with `--tags <role>` matched the include but **silently skipped** every
task inside `setup.yml` / `cleanup.yml` (role reported `ok=2 changed=0` while
doing nothing). Full plays were never affected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Fixes # (issue)

What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [X] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules
